### PR TITLE
Fix: `SuperSimplexNoise2D` → `GradientNoise2D` rename

### DIFF
--- a/Metal-Engine/Libraries/TerrainGenerationLibrary.swift
+++ b/Metal-Engine/Libraries/TerrainGenerationLibrary.swift
@@ -39,11 +39,11 @@ protocol TerrainGenerator: AnyObject {
 
 class BasicTerrainGenerator: TerrainGenerator {
     let seed: Int
-    let noise: SuperSimplexNoise2D
+    let noise: GradientNoise2D
     
     init(seed: Int) {
         self.seed = seed
-        self.noise = SuperSimplexNoise2D(amplitude: 4, frequency: 0.05, seed: seed)
+        self.noise = GradientNoise2D(amplitude: 4, frequency: 0.05, seed: seed)
     }
     
     func getApproxHeight(position: Position) -> Float {


### PR DESCRIPTION
swift-noise's `SuperSimplexNoise2D` was renamed `GradientNoise2D` and the old name was marked unavailable, so this fixes the ability to build.