### PR TITLE
Fix: Replaced usage of `[0..<3]` on `simd_float4` with `xyz: simd_float3` extension

### DIFF
--- a/Metal-Engine/Game/Node.swift
+++ b/Metal-Engine/Game/Node.swift
@@ -39,7 +39,10 @@ class Node {
     
     var normalMatrix: matrix_float3x3 {
         if ((prev_position != position) || (prev_scale != scale) || (prev_rotation != rotation)) {
-            _normalMatrix = float3x3(float3(Array((self.modelMatrix.columns.0)[0..<3])), float3(Array((self.modelMatrix.columns.1)[0..<3])), float3(Array((self.modelMatrix.columns.2)[0..<3])))
+            let column: simd_float4 = self.modelMatrix.columns.0
+            let arraySlice = column.xyz
+            let newSubArray = Array(arrayLiteral: arraySlice)
+            _normalMatrix = float3x3(self.modelMatrix.columns.0.xyz, self.modelMatrix.columns.1.xyz, self.modelMatrix.columns.2.xyz)
             _normalMatrix = _normalMatrix.inverse.transpose
             prev_position = position
             prev_scale = scale
@@ -72,4 +75,11 @@ class Node {
         }
     }
     
+}
+
+
+
+extension simd_float4
+{
+    var xyz: simd_float3 { simd_float3(x: self.x, y: self.y, z: self.z) }
 }


### PR DESCRIPTION
Wasn't compiling with Swift 5.7 compiler in 4.2 mode, because apparently the `func subscript(Range<Int>) -> ArraySlice<Element>` was removed from `simd_float4` at some point.  _(This isn't unheard of— Swift's SIMD library has had a bit of a rocky history of renames and changes that didn't respect backwards-compat that most of the rest of Swift obeys.  Personally, I got fed up of it a few years ago and wrote my own Swift wrapper lib for the C simd functions, so I feel the pain.)_

Replaced the code doing an range-subscript array slice, creating a new array, and initing a new `float3` with a simple extension method on `simd_float4` that provides a shader-like `var xyz: simd_float3` property, and using that instead.  Should work for all versions of Swift 4.x or 5.x.